### PR TITLE
implement leave group

### DIFF
--- a/apps/controllers/group/groupController.ts
+++ b/apps/controllers/group/groupController.ts
@@ -33,6 +33,16 @@ export class GroupController extends BaseController {
         }
     }
 
+    async leaveGroup(req: Request, res: Response): Promise<void> {
+        try {
+            const { id } = req.params;
+            const leaveGroup = await this.groupService.leaveGroup(Number(id), req.user?.user_id ?? -1);
+            this.handleSuccess(res, null, 200, "Left group successfully");
+        } catch (error) {
+            this.handleError(error, res);
+        }
+    }
+
     async removeGroupUser(req: Request, res: Response): Promise<void> {
         try {
             const { id } = req.params;

--- a/apps/routes/groupRouter.ts
+++ b/apps/routes/groupRouter.ts
@@ -46,6 +46,12 @@ export class GroupRouter extends BaseRouter {
             this.groupController.removeGroupUser.bind(this.groupController)
         );
 
+        this.router.delete(
+            "/:id/leave",
+            groupMiddleware,
+            this.groupController.leaveGroup.bind(this.groupController)
+        );
+
         this.router.patch(
             "/:id/owner",
             groupMiddleware,

--- a/apps/services/group/groupService.ts
+++ b/apps/services/group/groupService.ts
@@ -73,4 +73,25 @@ export class GroupService {
             throw new AppError("Failed to get group members", 500);
         }
     }
+
+    async leaveGroup(group_id: number, user_id: number) {
+        try {
+            const group = await this.grouprepository.findGroup(group_id);
+            if (group.group_leader_id === user_id) {
+                throw new AppError("Group leader cannot leave the group. Transfer ownership first.", 403);
+            }
+
+            const userRemove = await this.grouprepository.GroupMemberRemove({
+                "user_id": user_id,
+                "group_id": group_id
+            });
+            return userRemove;
+        } catch (error) {
+            if (error instanceof AppError) {
+                throw error;
+            }
+            throw new AppError("Failed to leave group", 500);
+        }
+    }
 }
+


### PR DESCRIPTION
This pull request adds a new feature that allows users to leave a group, with a restriction that the group leader cannot leave without transferring ownership first. The changes span the controller, service, and router layers to provide a complete implementation of this feature.

**Leave group feature:**

* Added a new `leaveGroup` method to `GroupController`, which handles requests for users to leave a group and returns a success response.
* Implemented the `leaveGroup` method in `GroupService`, including a check to prevent the group leader from leaving the group without transferring ownership, and delegating member removal to the repository.
* Registered a new DELETE route `/groups/:id/leave` in `GroupRouter` to expose the leave group functionality via the API.