### PR TITLE
Find my group

### DIFF
--- a/apps/controllers/group/groupController.ts
+++ b/apps/controllers/group/groupController.ts
@@ -96,4 +96,14 @@ export class GroupController extends BaseController {
             this.handleError(error, res);
         }
     }
+
+    async getMyGroups(req: Request, res: Response): Promise<void> {
+        try {
+            const userId = req.user?.user_id ?? -1;
+            const groups = await this.groupService.getMyGroups(userId);
+            this.handleSuccess(res, groups, 200, "User groups retrieved successfully");
+        } catch (error) {
+            this.handleError(error, res);
+        }
+    }
 }

--- a/apps/repository/Group/groupRepository.ts
+++ b/apps/repository/Group/groupRepository.ts
@@ -173,4 +173,30 @@ export class GroupRepository {
             throw new AppError("Cannot find specified group", 404);
         }
     }
+
+    async getUserGroups(user_id: number) {
+        try {
+            const user = await prisma.user.findUniqueOrThrow({
+                where: {
+                    user_id
+                },
+                include: {
+                    groups: {
+                        include: {
+                            members: {
+                                select: {
+                                    user_id: true,
+                                    first_name: true,
+                                    last_name: true
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            return user.groups;
+        } catch {
+            throw new AppError("Failed to fetch user's groups", 404);
+        }
+    }
 }

--- a/apps/routes/groupRouter.ts
+++ b/apps/routes/groupRouter.ts
@@ -62,6 +62,12 @@ export class GroupRouter extends BaseRouter {
             "/:id/members",
             this.groupController.getGroupMembers.bind(this.groupController)
         );
+
+        this.router.get(
+            "/my/groups",
+            groupMiddleware,
+            this.groupController.getMyGroups.bind(this.groupController)
+        );
     }
     
 }

--- a/apps/services/group/groupService.ts
+++ b/apps/services/group/groupService.ts
@@ -93,5 +93,17 @@ export class GroupService {
             throw new AppError("Failed to leave group", 500);
         }
     }
+
+    async getMyGroups(user_id: number) {
+        try {
+            const groups = await this.grouprepository.getUserGroups(user_id);
+            return groups;
+        } catch (error: unknown) {
+            if (error instanceof AppError) {
+                throw error;
+            }
+            throw new AppError("Failed to get user's groups", 500);
+        }
+    }
 }
 


### PR DESCRIPTION
This pull request adds a new feature that allows users to retrieve all groups they belong to. The implementation spans the controller, service, repository, and router layers, ensuring a full-stack integration of the new endpoint.

**New "Get My Groups" Endpoint:**

* Controller: Added `getMyGroups` method to `GroupController` to handle requests for fetching the groups of the currently authenticated user.
* Service: Implemented `getMyGroups` in `GroupService` to interact with the repository and handle errors appropriately.
* Repository: Added `getUserGroups` in `GroupRepository` to query the database for a user's groups, including group members' basic info.
* Router: Registered a new route `GET /my/groups` in `GroupRouter` with appropriate middleware and controller binding.