### PR TITLE
Feat:inter-travel

### DIFF
--- a/apps/controllers/user/userController.ts
+++ b/apps/controllers/user/userController.ts
@@ -35,6 +35,24 @@ export class UserController extends BaseController {
         }
     }
 
+    async getAllTravelStyles(req: Request, res: Response): Promise<void> {
+        try {
+            const travelStyles = await this.service.getAllTravelStyles();
+            this.handleSuccess(res, { travelStyles }, 200);
+        } catch (error) {
+            this.handleError(error, res);
+        }
+    }
+
+    async getAllInterests(req: Request, res: Response): Promise<void> {
+        try {
+            const interests = await this.service.getAllInterests();
+            this.handleSuccess(res, { interests }, 200);
+        } catch (error) {
+            this.handleError(error, res);
+        }
+    }
+
     async getInterests(req: Request, res: Response): Promise<void> {
         try {
             const email = req.body.email;

--- a/apps/repository/User/userRepository.ts
+++ b/apps/repository/User/userRepository.ts
@@ -4,6 +4,9 @@ import { Interest, User, TravelStyle } from "@/prisma/index";
 import { AppError } from "@/types/error/AppError";
 import axios from "axios";
 import { config } from "@/config/config";
+import { omit } from "zod/v4/core/util.cjs";
+import { de, id } from "zod/v4/locales/index.cjs";
+import { create } from "domain";
 
 export class UserRepository {
     async createNewUser(payload: authRegisterReq): Promise<User> {
@@ -59,6 +62,40 @@ export class UserRepository {
         }
 
         return user;
+    }
+
+    async getAllTravelStyles() : Promise<Partial<TravelStyle>[]> {
+        try {
+            const travelStyles = await prisma.travelStyle.findMany({
+                omit: {
+                    id: true,
+                    key: true,
+                    description: true,
+                    created_at: true,
+                    updated_at: true
+                },
+            });
+            return travelStyles;
+        } catch (error : any) {
+            throw new AppError(`Failed to fetch all travel styles: ${error.message}`, 500);
+        }
+    }
+
+    async getAllInterests() : Promise<Partial<Interest>[]> {
+        try {
+            const interests = await prisma.interest.findMany({
+                omit: {
+                    id: true,
+                    key: true,
+                    description: true,
+                    created_at: true,
+                    updated_at: true
+                },
+        });
+        return interests;
+        } catch (error : any) {
+            throw new AppError(`Failed to fetch all interests: ${error.message}`, 500);
+        }
     }
 
     async findExistingUser(email: string): Promise<boolean> {

--- a/apps/routes/userRouter.ts
+++ b/apps/routes/userRouter.ts
@@ -22,6 +22,16 @@ export class UserRouter extends BaseRouter {
             this.controller.updateUser.bind(this.controller)
         );
 
+        this.router.get(
+            "/interests/all",
+            this.controller.getAllInterests.bind(this.controller)
+        );
+
+        this.router.get(
+            "/travel-styles/all",
+            this.controller.getAllTravelStyles.bind(this.controller)
+        );
+
         // Define routes for user interests
         this.router.get(
             "/interests",

--- a/apps/services/user/userService.ts
+++ b/apps/services/user/userService.ts
@@ -90,6 +90,25 @@ export class UserService {
     }
 
     // Methods related to user interests
+
+    async getAllTravelStyles() : Promise<Partial<TravelStyle>[]> {
+        try {
+            const travelStyles = await this.repo.getAllTravelStyles();
+            return travelStyles;
+        } catch (error : any) {
+            throw new AppError(`Failed to fetch all travel styles: ${error.message}`, 500);
+        }
+    }
+
+    async getAllInterests() : Promise<Partial<Interest>[]> {
+        try {
+            const interests = await this.repo.getAllInterests();
+            return interests;
+        } catch (error : any) {
+            throw new AppError(`Failed to fetch all interests: ${error.message}`, 500);
+        }
+    }
+
     async getUserInterests(email: string) {
         try {
             const user = await this.repo.retrieveUser(email);


### PR DESCRIPTION
This pull request adds new endpoints and supporting logic to fetch all available travel styles and interests for users. The changes span the controller, service, repository, and router layers, ensuring that both travel styles and interests can be retrieved via dedicated API routes.

**New endpoints for fetching all travel styles and interests:**

* [`apps/routes/userRouter.ts`](diffhunk://#diff-52a1b3d46466d39f4cb2c7123735c5aad8e681fc56011394d93b085cb46b2344R25-R34): Added two new GET routes, `/interests/all` and `/travel-styles/all`, which map to the new controller methods for retrieving all interests and travel styles.

**Controller and service layer support:**

* [`apps/controllers/user/userController.ts`](diffhunk://#diff-668cb52b9a43c7c79e8cb429422f0b7c963391e1eb7fd263259e08f08fc1578bR38-R55): Introduced `getAllTravelStyles` and `getAllInterests` methods to handle the new routes and delegate to the service layer.
* [`apps/services/user/userService.ts`](diffhunk://#diff-e49f6202ee7ba4910d6ff86b0c45a589c0a42e3874206591e67e3704b418254aR93-R111): Added `getAllTravelStyles` and `getAllInterests` methods that interact with the repository to fetch the relevant data.

**Repository methods for data fetching:**

* [`apps/repository/User/userRepository.ts`](diffhunk://#diff-037ff25fee185c731d74f2f4f2b09aec9e8ddbdb2c1b59e284f330f4131cae4dR67-R100): Implemented `getAllTravelStyles` and `getAllInterests` methods to query the database for all travel styles and interests, omitting sensitive or unnecessary fields from the results.

**Minor dependency changes:**

* [`apps/repository/User/userRepository.ts`](diffhunk://#diff-037ff25fee185c731d74f2f4f2b09aec9e8ddbdb2c1b59e284f330f4131cae4dR7-R9): Added new imports, though some (such as from `zod` and `domain`) appear unused and could be cleaned up.