### PR TITLE
Fix get groupwithdetail

### DIFF
--- a/apps/repository/Group/groupRepository.ts
+++ b/apps/repository/Group/groupRepository.ts
@@ -304,12 +304,13 @@ export class GroupRepository {
                     }
                 }
             });
-
-            return {
-                ...group,
-                members: group.Belongs.map(b => b.User),
-                interests: group.groupInterests.map(gi => gi.interest)
+            const { Belongs, groupInterests, ...groupWithoutExcludedKeys } = group;
+            let payload = {
+                ...groupWithoutExcludedKeys,
+                members: Belongs.map(b => b.User),
+                interests: groupInterests.map(gi => gi.interest)
             };
+            return payload;
         } catch {
             throw new AppError("Cannot find specified group", 404);
         }

--- a/apps/services/group/groupService.ts
+++ b/apps/services/group/groupService.ts
@@ -11,7 +11,7 @@ export class GroupService {
 
     async getGroup(group_data: groupGetReq) {
         try {
-            const group = await this.grouprepository.findGroup(group_data.group_id);
+            const group = await this.grouprepository.getGroupWithDetails(group_data.group_id);
             return group;
         } catch (error: unknown) {
             //console.error(error)


### PR DESCRIPTION
This pull request refactors how group details are retrieved and returned, improving the clarity and consistency of the data structure. The main changes involve updating the repository and service layers to use a new method for fetching group details and to construct the returned group object more explicitly.

**Repository and data structure improvements:**

* Refactored the `GroupRepository` to exclude the `Belongs` and `groupInterests` keys from the returned group object, instead explicitly constructing the `members` and `interests` arrays from these relations. (`apps/repository/Group/groupRepository.ts`)

**Service layer update:**

* Updated the `GroupService` to use the new `getGroupWithDetails` method from the repository, ensuring that the service now returns the improved group details payload. (`apps/services/group/groupService.ts`)