### PR TITLE
Fix Interest Bug

### DIFF
--- a/apps/repository/User/userRepository.ts
+++ b/apps/repository/User/userRepository.ts
@@ -88,7 +88,7 @@ export class UserRepository {
             const interests = await prisma.interest.findMany({
                 omit: {
                     // id: true,
-                    key: true,
+                    // key: true,
                     description: true,
                     created_at: true,
                     updated_at: true,


### PR DESCRIPTION
This pull request includes a minor change to the `UserRepository` class, specifically in how interest fields are omitted during a database query. The `key` field is no longer being omitted, allowing it to be included in the query results.

* Stopped omitting the `key` field from the `interest` query results in `userRepository.ts`.