### PR TITLE
Feat:get UserPicture

### DIFF
--- a/apps/controllers/user/userController.ts
+++ b/apps/controllers/user/userController.ts
@@ -146,4 +146,20 @@ export class UserController extends BaseController {
             this.handleError(error, res);
         }
     }
+
+    async getUserProfilePicture(req: Request, res: Response): Promise<void> {
+        try {
+            //no need cookies, just need email
+            const email = req.params.email;
+            const pic = await this.service.getUserProfilePicture(email);
+            if (!pic) {
+                this.handleError(new Error("Profile picture not found"), res);
+                return;
+            }
+            res.set("Content-Type", "image/jpeg");
+            res.send(pic);
+        } catch (error) {
+            this.handleError(error, res);
+        }
+    }
 }

--- a/apps/repository/User/userRepository.ts
+++ b/apps/repository/User/userRepository.ts
@@ -184,6 +184,15 @@ export class UserRepository {
         });
     }
 
+    async getUserProfilePicture(user: User): Promise<Buffer | null> {
+        if (!user.profile_url) return null;
+        const response = await axios.get(
+            config.FILE_SERVER_URL + user.profile_url,
+            { responseType: "arraybuffer" }
+        );
+        return response.data;
+    }
+
     async getUserProfile(email: string): Promise<Partial<User> | null> {
         const user = await prisma.user.findFirst({
             where: { email },

--- a/apps/routes/userRouter.ts
+++ b/apps/routes/userRouter.ts
@@ -63,6 +63,11 @@ export class UserRouter extends BaseRouter {
             upload.single("profile"),
             this.controller.uploadUserProfile.bind(this.controller)
         );
+
+        this.router.get(
+            "/:email/profile_pic",
+            this.controller.getUserProfilePicture.bind(this.controller)
+        );
     }
 
     public getRouter(): Router {

--- a/apps/services/user/userService.ts
+++ b/apps/services/user/userService.ts
@@ -170,6 +170,25 @@ export class UserService {
         }
     }
 
+    async getUserProfilePicture(email : string) : Promise<Buffer | null> {
+        try {
+            const user = await this.repo.retrieveUser(email);
+            if (!user) {
+                throw new AppError("User not found", 404);
+            }
+            if (!user.profile_url) {
+                return null; // No profile picture set
+            }
+            const pic = await this.repo.getUserProfilePicture(user);
+            return pic;
+        } catch (error: any) {
+            throw new AppError(
+                `Failed to fetch user profile picture: ${error.message}`,
+                500
+            );
+        }
+    }
+
     async getUserTravelStyles(email: string) {
         try {
             const travelStyles = await this.repo.getUserTravelStylesByEmail(email);


### PR DESCRIPTION
This pull request introduces a new feature that allows clients to fetch a user's profile picture by email. The implementation spans the controller, service, repository, and router layers, ensuring a clean separation of concerns and error handling.

### New Feature: User Profile Picture Retrieval

* Added a new endpoint `GET /:email/profile_pic` to `UserRouter`, enabling clients to request a user's profile picture using their email.
* Implemented `getUserProfilePicture` in `UserController` to handle incoming requests, fetch the profile picture, and return it as a JPEG image.

### Service and Data Access Enhancements

* Added `getUserProfilePicture` to `UserService` to coordinate fetching the user and their profile picture, with appropriate error handling for missing users or profile URLs.
* Implemented `getUserProfilePicture` in `UserRepository` to retrieve the image from an external file server using the user's `profile_url`.
<img width="1390" height="986" alt="image" src="https://github.com/user-attachments/assets/639bdacc-0281-4026-91d9-18b789fa13f7" />
